### PR TITLE
Use MUI sizing for dialog, fixes #3

### DIFF
--- a/src/miradorDownloadPlugin.js
+++ b/src/miradorDownloadPlugin.js
@@ -74,6 +74,8 @@ class MiradorDownload extends Component {
           onClose={this.handleDialogClose}
           open={modalDisplayed}
           scroll="paper"
+          fullWidth
+          maxWidth="xs"
         >
           <DialogTitle disableTypography>
             <Typography variant="h2">Download</Typography>


### PR DESCRIPTION
While this doesn't use the specified `400px` it instead uses the build in material-ui responsive sizes. The next one up `sm` is 600.

@ggeisler is that ok? See `maxWidth` here: https://v3-9-0.material-ui.com/api/dialog/